### PR TITLE
Hotfix for fatal error with memcpy during loading some DICOM files

### DIFF
--- a/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
+++ b/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
@@ -266,10 +266,14 @@ uint8* UDICOMLoader::LoadAndConvertData(FString FilePath, FVolumeInfo& VolumeInf
 
 		// Copy to our giant array at the right spot for this slice.
 		// Increase TotalArray ptr by DataLength * SliceNumber to get to the start of the curren't slices memory.
-		if(TotalArray + (DataLength * SliceNumber) < TotalArray + TotalDataSize)
+		if ((DataLength * SliceNumber) < TotalDataSize)
+		{
 			memcpy(TotalArray + (DataLength * SliceNumber), DataArray, DataLength);
+		}
 		else
+		{
 			UE_LOG(LogTemp, Error, TEXT("DICOM Loader error during memcpy, some data might be missing"));
+		}
 
 		Parser.CloseFile();
 	}

--- a/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
+++ b/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
@@ -266,7 +266,10 @@ uint8* UDICOMLoader::LoadAndConvertData(FString FilePath, FVolumeInfo& VolumeInf
 
 		// Copy to our giant array at the right spot for this slice.
 		// Increase TotalArray ptr by DataLength * SliceNumber to get to the start of the curren't slices memory.
-		memcpy(TotalArray + (DataLength * SliceNumber), DataArray, DataLength);
+		if(TotalArray + (DataLength * SliceNumber) < TotalArray + TotalDataSize)
+			memcpy(TotalArray + (DataLength * SliceNumber), DataArray, DataLength);
+		else
+			UE_LOG(LogTemp, Error, TEXT("DICOM Loader error during memcpy, some data might be missing"));
 
 		Parser.CloseFile();
 	}


### PR DESCRIPTION
Many dicoms caused the plugin to crash, so I've added a quick hotfix for that. Works flawlessly, but actually this error should never happen, so it should be changed (memcpy arguments sometimes were wrong)