### PR TITLE
fix: uplugin EngineVersion with semantic versioning to 4.27.0

### DIFF
--- a/Source/FractalMarcher/Public/Rendering/FractalShaders.h
+++ b/Source/FractalMarcher/Public/Rendering/FractalShaders.h
@@ -26,7 +26,7 @@ struct FMandelbulbSDFResources
 
 	/// Mandelbulb volume texture.
 	UPROPERTY();
-	UVolumeTexture* MandelbulbVolume;
+	UVolumeTexture* MandelbulbVolume = nullptr;
 
 	/// The compute shader UAV. Used for all the calculations.
 	FUnorderedAccessViewRHIRef MandelbulbVolumeUAVRef;

--- a/Source/Raymarcher/Public/Rendering/RaymarchTypes.h
+++ b/Source/Raymarcher/Public/Rendering/RaymarchTypes.h
@@ -94,15 +94,15 @@ struct FBasicRaymarchRenderingResources
 
 	/// Pointer to the Data Volume texture.
 	UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Transient, Category = "Basic Raymarch Rendering Resources")
-	UVolumeTexture* DataVolumeTextureRef;
+	UVolumeTexture* DataVolumeTextureRef = nullptr;
 
 	/// Pointer to the Transfer Function Volume texture.
 	UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Transient, Category = "Basic Raymarch Rendering Resources")
-	UTexture2D* TFTextureRef;
+	UTexture2D* TFTextureRef = nullptr;
 
 	/// Pointer to the illumination volume texture render target.
 	UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Transient, Category = "Basic Raymarch Rendering Resources")
-	UTextureRenderTargetVolume* LightVolumeRenderTarget;
+	UTextureRenderTargetVolume* LightVolumeRenderTarget = nullptr;
 
 	/// If true, Light Volume texture will be created with it's side scaled down by 1/2 (-> 1/8 total voxels!)
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Basic Raymarch Rendering Resources")

--- a/TBRaymarcherPlugin.uplugin
+++ b/TBRaymarcherPlugin.uplugin
@@ -2,7 +2,7 @@
   "FileVersion": 3,
   "Version": 1,
   "VersionName": "0.9.1",
-  "EngineVersion": "4.26",
+  "EngineVersion": "4.27.0",
   "FriendlyName": "Tommy Bazar's Raymarcher Plugin",
   "Description": "A plugin for raymarching volumetric data",
   "Category": "Volumetrics",


### PR DESCRIPTION
uplugin, EngineVersion 4.27 but with semantic versioning 4.27.0 a projects DefaultEngine.ini no longer needs to have

```
; Disable warnings about empty engine version.

[Core.System]
ZeroEngineVersionWarning=False
```