### PR TITLE
Calculate spacing only with sensible values.

### DIFF
--- a/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
+++ b/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DICOMLoader.cpp
@@ -283,7 +283,10 @@ uint8* UDICOMLoader::LoadAndConvertData(FString FilePath, FVolumeInfo& VolumeInf
 	ParserHelper.GetSliceLocationFilenamePairs(SliceLocations, true);
 	if (SliceLocations.size() > 1)
 	{
-		VolumeInfo.Spacing.Z = abs(SliceLocations[1].first - SliceLocations[0].first);
+		if (abs(SliceLocations[1].first - SliceLocations[0].first) > 0)
+		{
+			VolumeInfo.Spacing.Z = abs(SliceLocations[1].first - SliceLocations[0].first);
+		}
 		VolumeInfo.WorldDimensions = VolumeInfo.Spacing * FVector(VolumeInfo.Dimensions);
 	}
 


### PR DESCRIPTION
Robustness for loading dicom files where "first" is not correctly set. Currently this could result in loading files with VolumeInfo.Spacing.Z incorrectly set to 0.